### PR TITLE
Add tilt & vibration sensors for door/window device

### DIFF
--- a/pyShelly/block.py
+++ b/pyShelly/block.py
@@ -8,7 +8,7 @@ from .utils import shelly_http_get
 from .switch import Switch
 from .relay import Relay
 from .powermeter import PowerMeter
-from .sensor import Sensor, Flood, DoorWindow, ExtTemp, ExtHumidity
+from .sensor import Sensor, Flood, DoorWindow, ExtTemp, ExtHumidity, Vibration
 from .light import RGBW2W, RGBW2C, RGBWW, Bulb, Duo, Vintage
 from .dimmer import Dimmer
 from .roller import Roller
@@ -274,6 +274,8 @@ class Block():
             self.unavailable_after_sec = SENSOR_UNAVAILABLE_SEC
             self._add_device(DoorWindow(self))
             self._add_device(Sensor(self, 66, 'illuminance', 'lux/value'))
+            self._add_device(Sensor(self, 88, 'tilt', 'angle/degrees'))
+            self._add_device(Vibration(self))
         elif self.type == 'SHBDUO-1':
             self._add_device(Duo(self))
             self._add_device(PowerMeter(self, 0, [213], tot_pos=214))

--- a/pyShelly/block.py
+++ b/pyShelly/block.py
@@ -274,7 +274,7 @@ class Block():
             self.unavailable_after_sec = SENSOR_UNAVAILABLE_SEC
             self._add_device(DoorWindow(self))
             self._add_device(Sensor(self, 66, 'illuminance', 'lux/value'))
-            self._add_device(Sensor(self, 88, 'tilt', 'angle/degrees'))
+            self._add_device(Sensor(self, 88, 'tilt', 'accel/tilt'))
             self._add_device(Vibration(self))
         elif self.type == 'SHBDUO-1':
             self._add_device(Duo(self))

--- a/pyShelly/sensor.py
+++ b/pyShelly/sensor.py
@@ -78,3 +78,10 @@ class DoorWindow(BinarySensor):
         super(DoorWindow, self).__init__(
             block, 55, 'door_window', 'sensor/state')
         self.sleep_device = True
+
+class Vibration(BinarySensor):
+    """Class to represent a vibration sensor"""
+    def __init__(self, block):
+        super(Vibration, self).__init__(
+            block, 99, 'vibration', 'sensor/state')
+        self.sleep_device = True

--- a/pyShelly/sensor.py
+++ b/pyShelly/sensor.py
@@ -83,5 +83,5 @@ class Vibration(BinarySensor):
     """Class to represent a vibration sensor"""
     def __init__(self, block):
         super(Vibration, self).__init__(
-            block, 99, 'vibration', 'sensor/state')
+            block, 99, 'vibration', 'accel/vibration')
         self.sleep_device = True


### PR DESCRIPTION
Thanks for the great work on integrating Shelly devices into home-assistant. I have some Door/Window sensors (version 1) and wanted to add tilt & vibration sensors to this library.
Using some trail and error I found the CoAP IDs for tilt to be `88` and vibration to be `99`.

~I'm not sure how I'd add this to the mqtt or poll interfaces, but I'm happy to help get this data from there too if that is wanted.~