### PR TITLE
Fixes for Shelly Plus US

### DIFF
--- a/pyShelly/block.py
+++ b/pyShelly/block.py
@@ -269,7 +269,7 @@ class Block(Base):
             #todo delayed reload
         #Shelly PLUG'S
         elif self.type == 'SHPLG-1' or self.type == 'SHPLG2-1' or \
-              self.type == 'SHPLG-S' or self.type == 'SHPLG-US':
+              self.type == 'SHPLG-S' or self.type == 'SHPLG-U1':
             self._add_device(Relay(self, 0))
             self._add_device(PowerMeter(self, 0))
         elif self.type == 'SHEM':

--- a/pyShelly/const.py
+++ b/pyShelly/const.py
@@ -154,7 +154,7 @@ SHELLY_TYPES = {
     'SHIX3-1': {'name': "Shelly i3", 'mqtt':'shellyix3'},
     'SHGS-1': {'name': "Shelly Gas", 'mqtt':'shellygas'},
     'SHAIR-1': {'name': "Shelly Air", 'mqtt':'ShellyAir'},
-    'SHPLUG-U1': {'name': "Shelly Plug US", 'mqtt':'shellyplugu1'},
+    'SHPLG-U1': {'name': "Shelly Plug US", 'mqtt':'shellyplugu1'},
     'SHUNI-1': {'name': "Shelly UNI", 'mqtt':'shellyuni'}
 }
 


### PR DESCRIPTION
Without these changes, my Shelly Plug USes are not picked up by ShellyForHASS in HomeAssistant.