### PR TITLE
Use different divider for Gen 2 power meters

### DIFF
--- a/pyShelly/block.py
+++ b/pyShelly/block.py
@@ -392,7 +392,7 @@ class Block(Base):
         elif self.type == 'ShellyPlus1PM':
             self.rpc = True
             self._add_device(Relay(self, 0))
-            self._add_device(PowerMeter(self, 0))
+            self._add_device(PowerMeter(self, 0, gen=2))
             self._add_device(Switch(self, 0))
         #Shelly 2
         elif self.type == 'SHSW-21':           
@@ -437,7 +437,7 @@ class Block(Base):
             self.rpc = True
             for channel in range(4):
                 self._add_device(Relay(self, channel + 1))
-                self._add_device(PowerMeter(self, channel + 1))
+                self._add_device(PowerMeter(self, channel + 1, gen=2))
                 self._add_device(Switch(self, channel + 1))
         elif self.type == 'SHRGBWW-01':
             self._add_device(RGBWW(self))

--- a/pyShelly/powermeter.py
+++ b/pyShelly/powermeter.py
@@ -19,7 +19,7 @@ from .const import (
 class PowerMeter(Device):
     """Class to represent a power meter value"""
     def __init__(self, block, channel, position = None,
-                 tot_pos = None, voltage_to_block=False, em=False, topic="emeter"):
+                 tot_pos = None, voltage_to_block=False, em=False, topic="emeter", gen=1):
         #Todo: voltage_to_block
         super(PowerMeter, self).__init__(block)
         self.id = block.id
@@ -48,7 +48,7 @@ class PowerMeter(Device):
             ATTR_TOPIC: ['relay/$/power', topic + '/$/power'],
             ATTR_RPC: 'switch:$/apower'
         }
-        divider = None if em else '/60'
+        divider = None if (em or gen == 2) else '/60'
         self._info_value_cfg = {
             INFO_VALUE_POWER_FACTOR : {
                 ATTR_POS: [114, 4110],


### PR DESCRIPTION
There are different [reports](https://github.com/StyraHem/ShellyForHASS/issues/638) discussing a invalid reported `total_consumption` for Shelly Plus devices. I think the root cause of this issue is that pyShelly [divides the obtained data by 60](https://github.com/mlq/pyShelly/blob/master/pyShelly/powermeter.py#L51) and, thus, converting from Wh to Wm. ShellyForHass [assumes that the unit is Wh](https://github.com/StyraHem/ShellyForHASS/blob/dce8dc4f9d6783575604d69f46cba238b63db094/custom_components/shelly/const.py#L165).

This PR changes the divider for Gen 2 devices. While the other reports only mentioned Gen 2 devices, I assume that the previous generation might also be affected but I do not have any of those devices. Therefore, the patch only applies this change to Gen 2. Please note that I am not experienced with this code base, so my approach might be not the right one but it could hint to a solution that would fix this issue. 