### PR TITLE
Fix Python 3 'urllib' error message

### DIFF
--- a/pyShelly/compat.py
+++ b/pyShelly/compat.py
@@ -25,6 +25,7 @@ if sys.version_info < (3,):
     def urlopen(x):
         return urllib2.urlopen(x)
 else:
+    import urllib.parse
     import urllib.request
 
     def ba2c(x):  # Convert bytearra to compatible bytearray

--- a/pyShelly/compat.py
+++ b/pyShelly/compat.py
@@ -25,6 +25,8 @@ if sys.version_info < (3,):
     def urlopen(x):
         return urllib2.urlopen(x)
 else:
+    import urllib.request
+
     def ba2c(x):  # Convert bytearra to compatible bytearray
         return x
 


### PR DESCRIPTION
When using Python 3.9.7, simply starting pyShell() produces this error
message:

    AttributeError: module 'urllib' has no attribute 'request'

Fix, by importing urllib.request before attempting to use
urllib.request.urlopen.

This small demo program triggers the error:

    #!/usr/bin/env python3
    
    import sys
    import time
    
    from pyShelly import pyShelly
    
    shelly = pyShelly()
    
    while True:
        try:
            time.sleep(60)
        except KeyboardInterrupt:
            print("Bye!")
            sys.exit(0)
